### PR TITLE
Fix handling of leading zeros during parsing

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -2173,6 +2173,11 @@ mod tests {
             BigFloat::from_u128(123456789012345678901234567890123456789)
                 == BigFloat::parse("1.23456789012345678901234567890123456789e+38").unwrap()
         );
+        // Regression Tests: If the number of leading zeros were equal to the number of remaining
+        // digits in the integral part, `parse` would always yield an exponent of 39.
+        assert!(ONE == BigFloat::parse("01").unwrap());
+        assert!(BigFloat::from_u32(987654321) == BigFloat::parse("000000000987654321.0").unwrap());
+        assert!(BigFloat::parse("9.9e-1") == BigFloat::parse("0099e-2"));
     }
 
     fn fmt_to_str<'a>(f: &BigFloat, buf: &'a mut [u8]) -> WritableBuf<'a> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -169,7 +169,7 @@ fn parse_digits(parser_state: &mut ParserState, skip_zeroes: bool, int: bool) ->
         }
         ch = parser_state.next_char();
     }
-    if skip_cnt == len {
+    if !int && skip_cnt == len {
         // just zeroes
         len = 0;
     }
@@ -218,7 +218,8 @@ mod tests {
         let mut buf = [0u8; 64];
 
         // combinations of possible valid components of a number and expected resulting characteristics.
-        let mantissas = ["0.0", "0", ".000", "00.", "00123", "456.", "789.012", ".3456", "0.0078"];
+        let mantissas =
+            ["0.0", "0", ".000", "00.", "00123", "456.", "789.012", ".3456", "0.0078", "01"];
         let expected_mantissas = [
             [
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -256,9 +257,13 @@ mod tests {
                 7, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
+            [
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ],
         ];
-        let expected_mantissa_len = [0, 0, 0, 0, 3, 3, 6, 4, 2];
-        let expected_exp_shifts = [0, 0, 0, 0, -37, -37, -37, -40, -42];
+        let expected_mantissa_len = [0, 0, 0, 0, 3, 3, 6, 4, 2, 1];
+        let expected_exp_shifts = [0, 0, 0, 0, -37, -37, -37, -40, -42, -39];
 
         let signs = ["", "+", "-"];
         let expected_signs = [1, 1, -1];


### PR DESCRIPTION
If the number of leading zeros matched the number of non-leading digits in the integral part of the input to `BigFloat::parse`, the resulting value would always have an exponent of 39.

Fixes: #10